### PR TITLE
Update README.md to include required subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ make collect
 ### Run It
 
 ```bash
-$ ./bin/manage.py
+$ ./bin/manage.py runserver
 ```
 
 Open up your web browser to http://localhost:8000


### PR DESCRIPTION
I'm not sure if the **_runserver_** subcommand was left out by accident or if it was not required in previous versions of Django but it seems to be required now.
